### PR TITLE
update bob testnet url and chain id

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -463,22 +463,6 @@
       }
     ]
   },
-  "111": {
-    "name": "BOB Testnet",
-    "description": "Hybrid L2 that combines the security of Bitcoin with the versatility of Ethereum.",
-    "logo": "https://uploads-ssl.webflow.com/644a5b7efad46e3cd70deafb/669a6c6b13d9cabc22dddfd3_BOB.png",
-    "ecosystem": "Bitcoin",
-    "isTestnet": true,
-    "layer": 2,
-    "rollupType": null,
-    "website": "https://www.gobob.xyz/",
-    "explorers": [
-      {
-        "url": "https://testnet-explorer.gobob.xyz/",
-        "hostedBy": "self"
-      }
-    ]
-  },
   "113": {
     "name": "Flare Network Coston2",
     "description": "Blockchain for data, EVM smart contract platform designed to expand the utility of blockchain.",
@@ -5907,6 +5891,22 @@
     "explorers": [
       {
         "url": "https://testnet.btscan.io/",
+        "hostedBy": "self"
+      }
+    ]
+  },
+  "808813": {
+    "name": "BOB Sepolia",
+    "description": "Hybrid L2 that combines the security of Bitcoin with the versatility of Ethereum.",
+    "logo": "https://uploads-ssl.webflow.com/644a5b7efad46e3cd70deafb/669a6c6b13d9cabc22dddfd3_BOB.png",
+    "ecosystem": "Bitcoin",
+    "isTestnet": true,
+    "layer": 2,
+    "rollupType": null,
+    "website": "https://www.gobob.xyz/",
+    "explorers": [
+      {
+        "url": "https://bob-sepolia.explorer.gobob.xyz/",
         "hostedBy": "self"
       }
     ]


### PR DESCRIPTION
We deprecated the previous testnet, see also: https://github.com/blockscout/docs/pull/327