### PR TITLE
Update chains.json

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -935,13 +935,13 @@
   },
   "248": {
     "name": "Oasys",
-    "description": "Decentralised blockchain video gaming platform with zero gas fees.",
+    "description": "Blockchain for Tokenized Asian Assets.",
     "logo": "https://uploads-ssl.webflow.com/644a5b7efad46e3cd70deafb/65afe545b7bec826fe8740c0_oasys.png",
-    "ecosystem": "Ethereum",
+    "ecosystem": "Oasys",
     "isTestnet": false,
     "layer": 1,
     "rollupType": null,
-    "website": "https://www.oasys.games/",
+    "website": "https://www.oasys-chain.net/",
     "explorers": [
       {
         "url": "https://explorer.oasys.games/",
@@ -4495,14 +4495,14 @@
     ]
   },
   "9372": {
-    "name": "Oasys HUB Testnet",
-    "description": "Gaming blockchain combing public and private blockchain technologies.",
+    "name": "Oasys Testnet",
+    "description": "Blockchain for Tokenized Asian Assets.",
     "logo": "https://uploads-ssl.webflow.com/644a5b7efad46e3cd70deafb/65afe545b7bec826fe8740c0_oasys.png",
-    "ecosystem": "Ethereum",
+    "ecosystem": "Oasys",
     "isTestnet": true,
     "layer": 1,
     "rollupType": null,
-    "website": "https://www.oasys.games/",
+    "website": "https://www.oasys-chain.net/",
     "explorers": [
       {
         "url": "https://explorer.testnet.oasys.games/",
@@ -5071,14 +5071,14 @@
     ]
   },
   "20197": {
-    "name": "Oasys Sand Verse",
-    "description": "Gaming blockchain combing public and private blockchain technologies.",
+    "name": "Oasys SAND Verse",
+    "description": "Blockchain for Tokenized Asian Assets.",
     "logo": "https://uploads-ssl.webflow.com/644a5b7efad46e3cd70deafb/65afe545b7bec826fe8740c0_oasys.png",
-    "ecosystem": "Ethereum",
+    "ecosystem": "Oasys",
     "isTestnet": true,
-    "layer": 1,
+    "layer": 2,
     "rollupType": null,
-    "website": "https://www.oasys.games/",
+    "website": "https://www.oasys-chain.net/",
     "explorers": [
       {
         "url": "https://explorer.sandverse.oasys.games/",


### PR DESCRIPTION
Hi,

I’m a member of the Oasys blockchain team.
I would like to submit a pull request to update the information in chains.json for the following three chains:

- Oasys (Mainnet)
- Oasys Testnet
- Oasys SAND Verse

Here are the key changes included in the pull request:
- The "ecosystem" field is currently set to "Ethereum", but since Oasys operates its own independent ecosystem, we have changed this to "Oasys".
- For SAND Verse, since it is a Layer 2 chain, we have updated the "layer" value from 1 to 2.
- The official website has been migrated from oasys.games to oasys-chain.net, so we have updated the corresponding URLs.
- We have unified the "description" field across all entries to: “Blockchain for Tokenized Asian Assets.”

Please note that for other Layer 2 chains such as HOME Verse and Saakuru Verse, different entities operate them. As such, any updates to those entries should be made by their respective operators.

Thank you very much for your time and consideration.