### PR TITLE
Add list endpoint to API

### DIFF
--- a/app/api/chains/list/route.ts
+++ b/app/api/chains/list/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
   try {
     const filePath = path.join(process.cwd(), 'data', 'chains.json');
     const jsonData = await fs.readFile(filePath, 'utf8');
-    const chainsData = JSON.parse(jsonData);
+    const chainsData = JSON.parse(jsonData) as Record<string, { name: string }>;
 
     const mappedData = Object.entries(chainsData).map(([chainid, { name }]) => ({
       name,

--- a/app/api/chains/list/route.ts
+++ b/app/api/chains/list/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { Chains } from '@/types';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -6,7 +7,7 @@ export async function GET() {
   try {
     const filePath = path.join(process.cwd(), 'data', 'chains.json');
     const jsonData = await fs.readFile(filePath, 'utf8');
-    const chainsData = JSON.parse(jsonData) as Record<string, { name: string }>;
+    const chainsData: Chains = JSON.parse(jsonData);
 
     const mappedData = Object.entries(chainsData).map(([chainid, { name }]) => ({
       name,

--- a/app/api/chains/list/route.ts
+++ b/app/api/chains/list/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function GET() {
+  try {
+    const filePath = path.join(process.cwd(), 'data', 'chains.json');
+    const jsonData = await fs.readFile(filePath, 'utf8');
+    const chainsData = JSON.parse(jsonData);
+
+    const mappedData = Object.entries(chainsData).map(([chainid, { name }]) => ({
+      name,
+      chainid,
+    }));
+
+    return NextResponse.json(mappedData);
+  } catch (error) {
+    console.error('Error reading chains data:', error);
+    return NextResponse.json({ error: 'Failed to load chains data' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Currently API either returns the full list of configured chain descriptions from the json file or one chain description if the specific chain id is provided. 

For MCP server it would be great to have an endpoint `/list` (`api/chains/list`) which will return the list of maps `{"name": "...", "chainid": "..."}` for all configured chain descriptions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blockscout/chainscout/pull/99?shareId=de9a7a9c-4273-4fa5-97d2-0ff18ae296cf).