### PR TITLE
Add PlatON Chain (chainId: 210425) and PlatON testnet (chainId:2206132)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -11099,5 +11099,39 @@
       }
     ],
     "logo": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQlBp6j3zKrobPEXOXGai2loMqYpBIAFWNHlg&s"
+  },
+  "210425": {
+    "name": "PlatON network",
+    "description": "PlatON is an open financial infrastructure initiated and promoted by the LatticeX Foundation.",
+    "logo": "https://www.platon.network/_next/static/media/logo3.905a5330.png",
+    "ecosystem": "Ethereum",
+    "isTestnet": false,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "LAT",
+    "website": "https://platon.network/",
+    "explorers": [
+      {
+        "url": "https://blockscout.platon.network/",
+        "hostedBy": "self"
+      }
+    ]
+  },
+  "2206132": {
+    "name": "PlatON testnet",
+    "description": "PlatON is an open financial infrastructure initiated and promoted by the LatticeX Foundation.",
+    "logo": "https://www.platon.network/_next/static/media/logo3.905a5330.png",
+    "ecosystem": "Ethereum",
+    "isTestnet": true,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "LAT",
+    "website": "https://platon.network/",
+    "explorers": [
+      {
+        "url": "https://devnet2blockscout.platon.network/",
+        "hostedBy": "self"
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Summary
This pull request adds the PlatON mainnet and testnet to Chainscout.

## Mainnet
**Chain Name**: PlatON network
**Chain ID**: 210425
**Description**: PlatON is an open financial infrastructure initiated and promoted by the LatticeX Foundation.
Explorer: https://blockscout.platon.network/
Website: https://platon.network/
Ecosystem: Ethereum
Native Currency: LAT

## Testnet
**Chain Name**: PlatON testnet
**Chain ID**: 2206132
**Description**: PlatON is an open financial infrastructure initiated and promoted by the LatticeX Foundation.
Explorer: https://devnet2blockscout.platon.network/
Website: https://platon.network/
Ecosystem: Ethereum
Native Currency: LAT

JSON validated successfully.