### PR TITLE
Update explorer URLs in chains.json

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -8165,7 +8165,7 @@
     "website": "https://to.nexus/",
     "explorers": [
       {
-        "url": "https://crossscan.io/",
+        "url": "https://www.crossscan.io/",
         "hostedBy": "blockscout"
       }
     ]
@@ -10787,7 +10787,7 @@
     "website": "https://redstone.xyz/",
     "explorers": [
       {
-        "url": "https://garnet.blockscout.com/",
+        "url": "https://explorer.garnetchain.com/",
         "hostedBy": "blockscout"
       }
     ]


### PR DESCRIPTION
This pull request makes minor updates to the explorer URLs for two networks in the `data/chains.json` file to ensure they point to the correct and current explorer sites.

- Updated the explorer URL for the Nexus network to use `https://www.crossscan.io/` instead of `https://crossscan.io/`.
- Updated the explorer URL for the Garnet (Redstone) network to use `https://explorer.garnetchain.com/` instead of `https://garnet.blockscout.com/`.