### PR TITLE
Add INRI CHAIN (chainId 3777)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -3913,7 +3913,7 @@
     "3777": {
     "name": "INRI CHAIN",
     "description": "EVM Proof-of-Work chain focused on fair mining, fee burning, and low transaction costs.",
-    "logo": "https://raw.githubusercontent.com/inrichain/logoinrichain/main/Logo..png",
+    "logo": "https://raw.githubusercontent.com/inrichain/logoofficial/main/256x256.png",
       "ecosystem": ["Ethereum"],
     "isTestnet": false,
     "layer": 1,


### PR DESCRIPTION
This PR adds INRI CHAIN (chainId 3777), an EVM Proof-of-Work L1 focused on fair mining, fee burning and low transaction costs.

- Website: https://inri.life
- Explorer: https://explorer.inri.life
- Native currency: INRI
