### PR TITLE
Update chains.json to add AICChain Mainnet and Testnet entries

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12743,6 +12743,40 @@
       }
     ],
     "logo": "https://tokens.larissa.network/logo.png"
+  },
+  "3018": {
+    "name": "AICChain Mainnet",
+    "description": "The world's first L1 public chain designed specifically for high-frequency RWA trading and AI compute trading.",
+    "logo": "https://aic-assets.aicchain.io/Logo_Black.png",
+    "ecosystem": "Ethereum",
+    "isTestnet": false,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "AIC",
+    "website": "https://aicchain.io/",
+    "explorers": [
+      {
+        "url": "https://scan.aicchain.io",
+        "hostedBy": "self"
+      }
+    ]
+  },
+  "30181": {
+    "name": "AICChain Testnet",
+    "description": "AICChain Testnet - The world's first L1 public chain designed specifically for high-frequency RWA trading and AI compute trading.",
+    "logo": "https://aic-assets.aicchain.io/Logo_Black.png",
+    "ecosystem": "Ethereum",
+    "isTestnet": true,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "tAIC",
+    "website": "https://aicchain.io/",
+    "explorers": [
+      {
+        "url": "https://testscan.aicchain.io",
+        "hostedBy": "self"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds AICChain Mainnet and Testnet support to Chainscout registry.
including its name, description, ecosystem, and other attributes.
### Networks Added

**AICChain Mainnet (Chain ID: 3018)**
- Type: Layer 1 Mainnet
- Currency: AIC

**AICChain Testnet (Chain ID: 30181)**
- Type: Layer 1 Testnet  
- Currency: tAIC


### Details

AICChain is the world's first L1 public chain designed specifically for high-frequency RWA trading and AI compute trading. Both mainnet and testnet have self-hosted block explorers and are fully EVM compatible.

### Validation

- ✅ JSON format validated
- ✅ All URLs verified and accessible
- ✅ Chain IDs unique and correct
- ✅ Follows existing format conventions