### PR TITLE
Add Robinhood Chain Testnet

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12708,6 +12708,24 @@
         "hostedBy": "blockscout"
       }
     ]
+  },
+  "46630": {
+    "name": "Robinhood Chain Testnet",
+    "description": "Public testnet for Robinhood Chain, an Ethereum L2 built on Arbitrum Orbit for financial-grade applications and tokenized real-world assets.",
+    "logo": "https://blockscout-icons.s3.us-east-1.amazonaws.com/robinhood-chain.svg",
+    "ecosystem": ["Arbitrum", "Ethereum"],
+    "isTestnet": true,
+    "layer": 2,
+    "settlementLayerChainId": "1",
+    "rollupType": "optimistic",
+    "native_currency": "ETH",
+    "website": "https://robinhood.com/chain",
+    "explorers": [
+      {
+        "url": "https://explorer.testnet.chain.robinhood.com/",
+        "hostedBy": "blockscout"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary
Adds Robinhood Chain Testnet (chain ID 46630) with its official Blockscout explorer.

## Changes
- New entry in `data/chains.json`
- Explorer: https://explorer.testnet.chain.robinhood.com/
- Hosted by: blockscout

Data-only contribution following repo guidelines.