### PR TITLE
Add BOT Chain Mainnet (chainId 677)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12709,6 +12709,23 @@
         "hostedBy": "blockscout"
       }
     ]
-  }
+  },
+  "677": {
+  "name": "BOT Chain Mainnet",
+  "description": "EVM 兼容 Layer 1，采用 Parlia（权威权益证明）共识，原生代币为 BOT。",
+  "ecosystem": "Ethereum",
+  "isTestnet": false,
+  "layer": 1,
+  "rollupType": null,
+  "native_currency": "BOT",
+  "website": "https://www.botchain.ai/",
+  "explorers": [
+    {
+      "url": "https://scan.botchain.ai/",
+      "hostedBy": "self"
+    }
+  ],
+  "logo": "https://www.botchain.ai/favicon.ico"
+}
 }
 


### PR DESCRIPTION
# Pull Request — Add BOT Chain Mainnet to Chainscout
## Summary
This PR adds **BOT Chain Mainnet** to the Chainscout directory (`data/chains.json`) so users can discover the network and its block explorer through [Chainscout](https://github.com/blockscout/chainscout).

BOT Chain is an EVM-compatible Layer 1 network (chain ID **677**) with native token **BOT**. The chain is already listed on [Chainlist](https://chainlist.org/chain/677).

## Changes

- Added a new entry for chain ID **`677`** in `data/chains.json`
- Registered the public block explorer: **https://scan.botchain.ai/**

## Chain metadata

| Field | Value |
|-------|--------|
| Chain ID | **677** (`0x2a5`) |
| Name | BOT Chain Mainnet |
| Native token | BOT (18 decimals) |
| Website | https://www.botchain.ai/ |
| RPC | https://rpc.botchain.ai |
| WebSocket RPC | wss://ws-rpc.botchain.ai |
| Block explorer | https://scan.botchain.ai/ |
| Chainlist | https://chainlist.org/chain/677 |
| Network type | Mainnet |
| Layer | 1 |
| Ecosystem | Ethereum (EVM-compatible) |
| Rollup | No (`rollupType: null`) |

## Explorer

| Field | Value |
|-------|--------|
| URL | https://scan.botchain.ai/ |
| hostedBy | `self` (team-operated explorer) |

## Verification

- [x] Explorer URL is publicly reachable
- [x] RPC endpoint responds (`eth_chainId` → `0x2a5` / 677)
- [x] Chain is listed on [Chainlist](https://chainlist.org/chain/677)
- [x] `data/chains.json` is valid JSON
- [x] Entry uses chain ID **`677`** as the object key

## Contact

<!-- Optional: add team contact for maintainers -->
- Team:
- Email / Telegram / Discord:
