### PR TITLE
Add GembaBlockchain Testnet (821207) to chains.json

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -8,7 +8,7 @@
     "layer": 1,
     "rollupType": null,
     "native_currency": "GMB",
-    "website": "https://gembascan.io",
+    "website": "https://gembachain.io",
     "explorers": [
       {
         "url": "https://testnet.gembascan.io/",

--- a/data/chains.json
+++ b/data/chains.json
@@ -1,4 +1,21 @@
 {
+  "821207": {
+    "name": "GembaBlockchain Testnet",
+    "description": "Public test network for GembaBlockchain \u2014 a decentralized, permissionless Cosmos EVM (CometBFT PoS) L1 whose native coin GMB is a utility coin.",
+    "logo": "https://testnet.gembascan.io/brand/gemba-bold-256.png",
+    "ecosystem": ["Cosmos", "EVM"],
+    "isTestnet": true,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "GMB",
+    "website": "https://gembascan.io",
+    "explorers": [
+      {
+        "url": "https://testnet.gembascan.io/",
+        "hostedBy": "self"
+      }
+    ]
+  },
   "1": {
     "name": "Ethereum",
     "description": "Decentralized global computing platform supporting smart contracts & P2P apps.",


### PR DESCRIPTION
  Description:
  Adds GembaBlockchain Testnet (chainId 821207) to the Chainscout directory.

  - Self-hosted Blockscout explorer: https://testnet.gembascan.io
  - Cosmos EVM (CometBFT PoS) public test network; native coin GMB
  - /assets/envs.js is live (current Blockscout version)
  
  data/chains.json: added the "821207" entry (logo + explorer URL self-hosted, all reachable).
