### PR TITLE
Add LUST Chain mainnet (chain ID 6923)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -4974,6 +4974,23 @@
       }
     ]
   },
+  "6923": {
+    "name": "LUST Chain",
+    "description": "LUST Chain is an EVM-compatible Layer 1 blockchain powered by LQC consensus, built for decentralized applications, DeFi, NFTs, public participation, and low-cost transactions. Official website: https://lustchain.org/. Ecosystem platform: https://platform.lustchain.org/.",
+    "logo": "https://explorer.lustchain.org/lust-assets/github/lst-icon.png",
+    "ecosystem": "Ethereum",
+    "isTestnet": false,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "LST",
+    "website": "https://lustchain.org/",
+    "explorers": [
+      {
+        "url": "https://explorer.lustchain.org/",
+        "hostedBy": "self"
+      }
+    ]
+  },
   "6969": {
     "name": "Tomb",
     "description": "Fast and secure Optimistic Rollup built on Fantom.",


### PR DESCRIPTION
## Summary

Adds LUST Chain mainnet to Chainscout with its official website, ecosystem platform, native currency, official logo, and self-hosted Blockscout explorer.

## Network details

* Chain name: LUST Chain
* Chain ID: 6923
* Network type: Mainnet
* Layer: L1
* Ecosystem: Ethereum
* Native currency: LST
* Consensus: LQC
* Official website: https://lustchain.org/
* Ecosystem platform: https://platform.lustchain.org/
* Explorer: https://explorer.lustchain.org/
* Hosting: Self-hosted Blockscout
* Logo: https://explorer.lustchain.org/lust-assets/github/lst-icon.png

## Verification

* The official LUST Chain website is publicly accessible.
* The LUST ecosystem platform is publicly accessible.
* The LUST Chain explorer is publicly accessible.
* The network is EVM-compatible.
* The explorer uses Blockscout.
* The official logo is publicly accessible through HTTPS.
* The LUST Chain mainnet chain ID is 6923.
