### PR TITLE
Add GridMind Testnet

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -16,6 +16,27 @@
       }
     ]
   },
+  "20260532": {
+    "name": "GridMind Testnet",
+    "description": "EVM-compatible public testnet pilot for GridMind Wallet, resource intelligence workflows, and early wallet/explorer testing.",
+    "logo": "https://www.grid-mind.com/logo.png",
+    "ecosystem": ["Ethereum", "EVM", "RWA"],
+    "isTestnet": true,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "testGRD",
+    "website": "https://www.grid-mind.com/blockchain",
+    "explorers": [
+      {
+        "url": "https://gridmindblockchain.com/",
+        "hostedBy": "self"
+      },
+      {
+        "url": "https://testnet-explorer.grid-mind.com/",
+        "hostedBy": "self"
+      }
+    ]
+  },
   "1": {
     "name": "Ethereum",
     "description": "Decentralized global computing platform supporting smart contracts & P2P apps.",


### PR DESCRIPTION
Summary:
- Adds GridMind Testnet to `data/chains.json`.
- Includes the GridMind campaign page, hosted logo, native test currency, and two public Blockscout explorer URLs.
- Marks the network as an L1 testnet.

Validation:
- Parsed `data/chains.json` with Node JSON parser.
- Verified GridMind logo, website, and explorer URLs return HTTP 200.

Notes:
- GridMind Testnet chain ID is `20260532`.
- Explorer URLs: `https://gridmindblockchain.com/` and `https://testnet-explorer.grid-mind.com/`.