### PR TITLE
fix: update Robinhood Chain Testnet logo and hostedBy tag

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12711,7 +12711,7 @@
   "46630": {
     "name": "Robinhood Chain Testnet",
     "description": "Public testnet for Robinhood Chain, an Ethereum L2 built on Arbitrum Orbit for financial-grade applications and tokenized real-world assets.",
-    "logo": "https://blockscout-icons.s3.us-east-1.amazonaws.com/robinhood-chain.svg",
+    "logo": "https://bs-static-content.blockscout.com/robinhood-config/icon-light.svg",
     "ecosystem": ["Arbitrum", "Ethereum"],
     "isTestnet": true,
     "layer": 2,
@@ -12722,7 +12722,7 @@
     "explorers": [
       {
         "url": "https://explorer.testnet.chain.robinhood.com/",
-        "hostedBy": "self-hosted"
+        "hostedBy": "blockscout"
       }
     ]  
   },


### PR DESCRIPTION
## Summary
Fixes the missing/broken icon for Robinhood Chain Testnet (chain ID 46630) on Chainscout and corrects the hosting tag.

## Changes
- Updated `logo` URL to the official working Robinhood feather icon (same as mainnet branding).
- Changed `hostedBy` from "self-hosted"/unknown to `"blockscout"` so it displays correctly as "Hosted by Blockscout".

## Why
- Previous S3 URL was returning 403 / broken image.
- Matches the official Blockscout-hosted explorer and original addition PR intent.

## Verification
- Logo now renders properly (feather symbol).
- Tag will show "Hosted by Blockscout" instead of "Unknown".
- Tested locally on `localhost:3000` with search "robin".

## Related
- Original addition: https://github.com/blockscout/chainscout/pull/230
