### PR TITLE
fix: update Robinhood Chain Testnet logo URL to fix missing/broken icon

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12732,7 +12732,7 @@
   "46630": {
     "name": "Robinhood Chain Testnet",
     "description": "Public testnet for Robinhood Chain, an Ethereum L2 built on Arbitrum Orbit for financial-grade applications and tokenized real-world assets.",
-    "logo": "https://blockscout-icons.s3.us-east-1.amazonaws.com/robinhood-chain.svg",
+    "logo": "https://bs-static-content.blockscout.com/robinhood-config/icon-light.svg",
     "ecosystem": ["Arbitrum", "Ethereum"],
     "isTestnet": true,
     "layer": 2,


### PR DESCRIPTION
## Summary
The Robinhood Chain Testnet (chain ID 46630) was showing a broken/missing icon in the chains list on https://chains.blockscout.com because its `logo` URL pointed to a non-existent file on the S3 bucket. (See attached screenshot)

## Changes
- Updated `"logo"` field for chain `46630` in `data/chains.json` to use the same working Blockscout-hosted icon already used by the mainnet entry (`4663`).

This fixes the broken placeholder icon shown next to "Robinhood Chain Testnet".

## Verification
- The new URL (`https://bs-static-content.blockscout.com/robinhood-config/icon-light.svg`) is already live and working for the mainnet.



<img width="1346" height="233" alt="image" src="https://github.com/user-attachments/assets/12790dcc-953d-4dbf-bb1d-6772693449a7" />