### PR TITLE
Add Haus Chain Testnet (2443)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -1,4 +1,24 @@
 {
+  "2443": {
+    "name": "Haus Chain Testnet",
+    "description": "EVM-compatible Layer 1 testnet for Haus Chain, designed for fast smart-contract development, testing and onchain applications.",
+    "logo": "https://dex-testnet.hausserver.xyz/token-logos/haus.webp",
+    "ecosystem": [
+      "Ethereum",
+      "EVM"
+    ],
+    "isTestnet": true,
+    "layer": 1,
+    "rollupType": null,
+    "native_currency": "HAUS",
+    "website": "https://www.hausserver.xyz/",
+    "explorers": [
+      {
+        "url": "https://explorer-testnet.hausserver.xyz/",
+        "hostedBy": "self"
+      }
+    ]
+  },
   "88118": {
     "name": "Shark Network",
     "description": "Shark Network is a high-performance EVM-compatible blockchain designed for the next generation of decentralized applications.",


### PR DESCRIPTION
## Add Haus Chain Testnet

Adds Haus Chain Testnet to ChainScout.

- Chain: Haus Chain Testnet
- Chain ID: 2443
- Chain ID hex: 0x98b
- Native currency: HAUS
- Layer: 1
- Ecosystem: Ethereum / EVM
- Network type: Testnet
- Explorer: https://explorer-testnet.hausserver.xyz/
- Website: https://www.hausserver.xyz/
- Explorer hosting: self-hosted Blockscout
- Logo: https://dex-testnet.hausserver.xyz/token-logos/haus.webp

### Validation

- Live RPC reports `eth_chainId = 0x98b`
- Explorer reachable
- Website reachable
- Logo reachable
- `data/chains.json` validates successfully
- ChainScout production build passes
