### PR TITLE
Add Whitechain Sepolia (chain 1874)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12715,6 +12715,26 @@
         "hostedBy": "conduit"
       }
     ]
+  },
+  "1874": {
+    "name": "Whitechain Sepolia",
+    "description": "Public testnet of Whitechain, the EVM network backed by WhiteBIT. An OP Stack optimistic rollup that settles to Ethereum Sepolia, with WBT as the native gas token, 1s block time and a public faucet.",
+    "logo": "https://whitechain.io/icon.svg",
+    "ecosystem": [
+      "Ethereum",
+      "Optimism"
+    ],
+    "isTestnet": true,
+    "layer": 2,
+    "rollupType": "optimistic",
+    "native_currency": "WBT",
+    "website": "https://whitechain.io/",
+    "explorers": [
+      {
+        "url": "https://explorer.testnet.whitechain.io/",
+        "hostedBy": "self"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
Adds **Whitechain Sepolia** (chain ID `1874`) to `data/chains.json`.

| Field | Value |
| --- | --- |
| Chain ID | 1874 (0x752) |
| Layer | 2 – OP Stack optimistic rollup, settles to Ethereum Sepolia (11155111) |
| Native currency | WBT (18 decimals) |
| RPC | https://rpc.testnet.whitechain.io |
| Explorer | https://explorer.testnet.whitechain.io/ |
| Faucet | https://faucet.testnet.whitechain.io/ |
| Website | https://whitechain.io/ |

Notes:

- The explorer is a Blockscout instance running on Whitechain's own infrastructure, so `hostedBy` is `self`. Verified live: `GET /api/v2/config/backend-version` returns `{"backend_version":"sha-6d9d538d98"}`.
- Chain ID, RPC, faucet and explorer match the `ethereum-lists/chains` entry `eip155-1874`.
- Logo is served from the official site: `https://whitechain.io/icon.svg` (512x512 SVG, HTTP 200).
- `jq . data/chains.json` passes; the change is a single appended entry with no other edits.
