### PR TITLE
Add PropTech Mainnet (chain 88788)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12698,7 +12698,27 @@
         "hostedBy": "conduit"
       }
     ]
-  }
+  },
+    "88788": {
+      "name": "PropTech Mainnet",
+      "description": "PropTech Blockchain is an EVM-compatible Layer 1 network for the global PropTech ecosystem.",
+      "logo": "https://explorer.ptekcoin.com/assets/configs/network_icon.png",
+      "ecosystem": [
+        "Ethereum",
+        "EVM"
+      ],
+      "isTestnet": false,
+      "layer": 1,
+      "rollupType": null,
+      "native_currency": "PTEK",
+      "website": "https://ptek.ai/",
+      "explorers": [
+        {
+          "url": "https://explorer.ptekcoin.com/",
+          "hostedBy": "self"
+        }
+      ]
+    }
 }
 
 


### PR DESCRIPTION
## Chain details

Adds PropTech Mainnet to Chainscout.

- Chain ID: `88788`
- Network type: EVM-compatible Layer 1 mainnet
- Native currency: `PTEK`
- Explorer: https://explorer.ptekcoin.com/
- Website: https://ptek.ai/
- Hosting: self-hosted Blockscout

The website, Explorer, and logo URLs are publicly accessible.