### PR TITLE
Add WorkChain Testnet (chain 1114)

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -12718,6 +12718,26 @@
         "hostedBy": "self"
       }
     ]
+  },
+    "1114": {
+    "name": "WorkChain Testnet",
+    "description": "Public testnet of WorkChain, a sovereign Ethereum Layer 2 OP Stack rollup purpose-built for the decentralized freelance and gig economy with native escrow and zero platform commissions.",
+    "logo": "https://explorer.workchain.website/workchain-icon.png",
+    "ecosystem": [
+      "Ethereum",
+      "Optimism"
+    ],
+    "isTestnet": true,
+    "layer": 2,
+    "rollupType": "optimistic",
+    "native_currency": "WORK",
+    "website": "https://workchain.website/",
+    "explorers": [
+      {
+        "url": "https://explorer.workchain.website/",
+        "hostedBy": "self"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
Adds **WorkChain Testnet** (chain ID `1114`) to `data/chains.json`.

| Field | Value |
| --- | --- |
| Chain ID | 1114 (0x45A) |
| Layer | 2 — OP Stack optimistic rollup, settles to Ethereum Sepolia (11155111) |
| Native currency | WORK (18 decimals) |
| RPC | https://rpc.workchain.website |
| Explorer | https://explorer.workchain.website/ |
| Website | https://workchain.website/ |
| Faucet | https://workchain.website/ |

### Verification Details:
- **Explorer Verification**: Self-hosted Blockscout instance running on WorkChain infrastructure (`hostedBy: "self"`).
- **Backend Status**: Verified live via `GET https://explorer.workchain.website/api/v2/config/backend-version`.
- **Logo**: Served directly from official explorer domain at `https://explorer.workchain.website/workchain-icon.png` (HTTP 200, 512x512 square PNG emblem).
- **Validation**: All URLs tested and verified reachable (`HTTP 200`), JSON passes `jq . data/chains.json`.
